### PR TITLE
Unngår sårbarheiter i commons-compress

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,6 +21,16 @@
         <common.version>3.2023.12.12_13.53-510909d4aa1a</common.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <repositories>
         <repository>
             <id>confluent</id>


### PR DESCRIPTION
Det er sårbarheiter i commons-compress, inkludert ein kategorisert som high. Tar derfor i bruk nyaste patch-versjon, der sårbarheitene er retta. Den gamle versjonen kjem inn transitivt via Apache Avro, som oppdaterast (altfor, spør du meg) sjeldan, så det er ikkje godt å seie kor fort neste versjon der kjem.

Har gått nøye gjennom release notes for Commons Compress mellom 1.22.0, som vi køyrer på i dag og som kom allereie i november 22, og 1.26.0, og det ser ut til å vera utelukkande små feilrettingar, kan ikkje sjå noko risikabelt der