### PR TITLE
Legger til mulighet for å lese meldinger fra alle partisjoner

### DIFF
--- a/api/src/main/kotlin/no/nav/kafkamanager/controller/KafkaAdminController.kt
+++ b/api/src/main/kotlin/no/nav/kafkamanager/controller/KafkaAdminController.kt
@@ -53,6 +53,7 @@ class KafkaAdminController(
 
     data class ReadTopicRequest(
         val topicName: String,
+        val topicAllPartitions: Boolean,
         val topicPartition: Int,
         val maxRecords: Int,
         val fromOffset: Long,

--- a/api/src/main/kotlin/no/nav/kafkamanager/domain/KafkaRecord.kt
+++ b/api/src/main/kotlin/no/nav/kafkamanager/domain/KafkaRecord.kt
@@ -1,6 +1,7 @@
 package no.nav.kafkamanager.domain
 
 data class KafkaRecord(
+    val partition: Int,
     val key: String?,
     val value: String?,
     val headers: List<KafkaRecordHeader>,

--- a/api/src/main/kotlin/no/nav/kafkamanager/utils/DTOMappers.kt
+++ b/api/src/main/kotlin/no/nav/kafkamanager/utils/DTOMappers.kt
@@ -20,6 +20,7 @@ object DTOMappers {
 
     fun toKafkaRecordHeader(consumerRecord: ConsumerRecord<String, String>): KafkaRecord {
         return KafkaRecord(
+            partition = consumerRecord.partition(),
             key = consumerRecord.key(),
             value = consumerRecord.value(),
             timestamp = consumerRecord.timestamp(),

--- a/api/src/test/kotlin/no/nav/kafkamanager/service/KafkaAdminServiceTest.kt
+++ b/api/src/test/kotlin/no/nav/kafkamanager/service/KafkaAdminServiceTest.kt
@@ -10,7 +10,8 @@ import org.junit.jupiter.api.Test
 class KafkaAdminServiceTest {
 
     private val records = listOf(
-        KafkaRecord( 
+        KafkaRecord(
+            partition = 0,
             key = "",
             value = "",
             headers = emptyList(),
@@ -18,6 +19,7 @@ class KafkaAdminServiceTest {
             offset = 123
         ),
         KafkaRecord(
+            partition = 0,
             key = null,
             value = null,
             headers = emptyList(),
@@ -25,6 +27,7 @@ class KafkaAdminServiceTest {
             offset = 124
         ),
         KafkaRecord(
+            partition = 0,
             key = "key123",
             value = "value123",
             headers = emptyList(),
@@ -32,6 +35,7 @@ class KafkaAdminServiceTest {
             offset = 125
         ),
         KafkaRecord(
+            partition = 0,
             key = "key1234",
             value = "value1234",
             headers = emptyList(),
@@ -39,6 +43,7 @@ class KafkaAdminServiceTest {
             offset = 126
         ),
         KafkaRecord(
+            partition = 0,
             key = "key9876",
             value = "value9876",
             headers = emptyList(),

--- a/web-app/src/api/index.ts
+++ b/web-app/src/api/index.ts
@@ -16,6 +16,7 @@ export function me(): AxiosPromise<User> {
 
 export interface ReadFromTopicRequest {
 	topicName: string;
+	topicAllPartitions: boolean,
 	topicPartition: number;
 	maxRecords: number;
 	fromOffset: number;
@@ -40,6 +41,7 @@ export interface SetConsumerOffsetRequest {
 }
 
 export interface KafkaRecord {
+	partition: number;
 	key: string | null;
 	value: string | null;
 	timestamp: number;
@@ -65,6 +67,7 @@ export function readFromTopic(request: ReadFromTopicRequest): AxiosPromise<Kafka
 	return axiosInstance.post(`/api/kafka/read-topic`, {
 		topicName: request.topicName,
 		topicPartition: request.topicPartition,
+		topicAllPartitions: request.topicAllPartitions,
 		maxRecords: request.maxRecords,
 		fromOffset: request.fromOffset,
 		filter: {

--- a/web-app/src/mock/api.ts
+++ b/web-app/src/mock/api.ts
@@ -11,6 +11,7 @@ for (let i = 0; i < 25; i++) {
 	const offset = i + 10000;
 
 	kafkaRecords.push({
+		partition: 0,
 		key: key.toString(),
 		value:
 			'{"aktoerid":"xxxxxxx","fodselsnr":"xxxxxxxx","formidlingsgruppekode":"ARBS","iserv_fra_dato":null,"etternavn":"TESTERSEN","fornavn":"TEST","nav_kontor":"0425","kvalifiseringsgruppekode":"IKVAL","rettighetsgruppekode":"IYT","hovedmaalkode":"SKAFFEA","sikkerhetstiltak_type_kode":null,"fr_kode":null,"har_oppfolgingssak":true,"sperret_ansatt":false,"er_doed":false,"doed_fra_dato":null,"endret_dato":"2021-03-28T20:11:12+02:00"}',
@@ -44,7 +45,7 @@ const topicPartitionOffsets: TopicPartitionOffset[] = [
 
 function mockUuidv4(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    var r = (Math.random() * 16) | 0,
+    const r = (Math.random() * 16) | 0,
         v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });

--- a/web-app/src/view/kafka-admin/kafka-record-modal-content.tsx
+++ b/web-app/src/view/kafka-admin/kafka-record-modal-content.tsx
@@ -11,13 +11,14 @@ export function KafkaRecordModalContent(props: { record: KafkaRecord | null }) {
 		return null;
 	}
 
-	const { key, value, offset, timestamp, headers } = props.record;
+	const { partition, key, value, offset, timestamp, headers } = props.record;
 	const safeValue = value || '';
 	const isRecordValueJson = isJson(safeValue);
 
 	return (
 		<div className="kafka-record-modal-content">
 			<div className="blokk-m">
+				<TextField label="Partition" value={partition} readOnly={true} />
 				<TextField label="Offset" value={offset} readOnly={true} />
 				<TextField label="Key" value={key || 'NO_KEY'} readOnly={true} />
 				<TextField label="Timestamp" value={toTimestamp(timestamp)} readOnly={true} />


### PR DESCRIPTION
Vi bruker kafka-manager en del. Topicene våre har 6 partisjoner, så for å finne riktige meldinger må vi manuelt iterere over hver partisjon i UI-et.

Denne PR-en legger til mulighet for å enkelt lese meldinger fra alle partisjoner

Legger til radioknapper, for å velge om man vil lese meldinger fra alle, eller èn spesifik partisjon.
![image](https://github.com/navikt/kafka-manager/assets/701351/04702b75-89fc-450f-a0ae-1e1654febddd)

Legger til partisjonsfelt i meldingsliste, og i meldings-modal.
![image](https://github.com/navikt/kafka-manager/assets/701351/254e0bea-bdf9-42c0-8187-6cb06e89409a)
