### PR TITLE
Ny dag, ny Spring Boot-oppgradering

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.3.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Primært for å komme oss vekk frå https://github.com/advisories/GHSA-gvpg-vgmx-xg6w , som kjem inn transitivt via noverande Spring Boot-versjon, men uansett fint å halde tritt.