### PR TITLE
Går over frå å basere dockerfila på baseimages-repoet til rein distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
+FROM gcr.io/distroless/java21
+ENV TZ="Europe/Oslo"
+WORKDIR /app
 COPY /api/target/kafka-manager.jar app.jar
 COPY /web-app/dist /app/public
+EXPOSE 8080
+USER nonroot
+CMD ["app.jar"]


### PR DESCRIPTION
baseimages-repoet inneheld mykje som ikkje er nødvendig for køyring på GCP, er litt varierande vedlikehalde og er litt uoversiktleg. Synes det er mykje greiare og tydelegare å køyre direkte på distroless-basert java-image.

Testa i etterlatte med temp-release av denne, funka fint.